### PR TITLE
Fix constant itn w/ large link_dim

### DIFF
--- a/src/elementary_functions.jl
+++ b/src/elementary_functions.jl
@@ -24,7 +24,7 @@ function const_itensornetwork(s::IndsNetworkMap; c=default_c_value(), linkdim::I
   for v in vertices(ψ)
     sinds = inds(s, v)
     virt_inds = setdiff(inds(ψ[v]), sinds)
-    ψ[v] = c^inv_L * c_tensor(only(sinds), virt_inds)
+    ψ[v] = c^inv_L * c_tensor(only(sinds), virt_inds) / linkdim^inv_L
   end
 
   return ψ

--- a/src/elementary_functions.jl
+++ b/src/elementary_functions.jl
@@ -24,7 +24,7 @@ function const_itensornetwork(s::IndsNetworkMap; c=default_c_value(), linkdim::I
   for v in vertices(ψ)
     sinds = inds(s, v)
     virt_inds = setdiff(inds(ψ[v]), sinds)
-    ψ[v] = c^inv_L * c_tensor(only(sinds), virt_inds) / linkdim^inv_L
+    ψ[v] = (c / linkdim)^inv_L * c_tensor(only(sinds), virt_inds)
   end
 
   return ψ

--- a/test/test_itensorfunction.jl
+++ b/test/test_itensorfunction.jl
@@ -44,14 +44,8 @@ end
     x = 0.5
     fx_x = calculate_fx(ψ_fx, x; alg="exact")
     @test fx_x ≈ c
-  end
-
-  @testset "test const w/ linkdims" begin
-    L = 3
-    g = named_grid((L, L))
-    s = continuous_siteinds(g)
-    c = 1.5
-
+    
+    # link dims section
     ψ_fx = const_itn(s; c, linkdim=4)
 
     x = 0.5

--- a/test/test_itensorfunction.jl
+++ b/test/test_itensorfunction.jl
@@ -44,7 +44,7 @@ end
     x = 0.5
     fx_x = calculate_fx(ψ_fx, x; alg="exact")
     @test fx_x ≈ c
-    
+
     # link dims section
     ψ_fx = const_itn(s; c, linkdim=4)
 

--- a/test/test_itensorfunction.jl
+++ b/test/test_itensorfunction.jl
@@ -42,12 +42,22 @@ end
     ψ_fx = const_itn(s; c)
 
     x = 0.5
-    ind_to_ind_value_map = calculate_ind_values(ψ_fx, x)
-
     fx_x = calculate_fx(ψ_fx, x)
     @test fx_x ≈ c
   end
 
+  @testset "test const w/ linkdims" begin
+    L = 3
+    g = named_grid((L, L))
+    s = continuous_siteinds(g)
+    c = 1.5
+
+    ψ_fx = const_itn(s; c, linkdim=4)
+
+    x = 0.5
+    fx_x = calculate_fx(ψ_fx, x)
+    @test fx_x ≈ c
+  end
   funcs = [
     ("cosh", cosh_itn, cosh),
     ("sinh", sinh_itn, sinh),

--- a/test/test_itensorfunction.jl
+++ b/test/test_itensorfunction.jl
@@ -42,7 +42,7 @@ end
     ψ_fx = const_itn(s; c)
 
     x = 0.5
-    fx_x = calculate_fx(ψ_fx, x)
+    fx_x = calculate_fx(ψ_fx, x; alg="exact")
     @test fx_x ≈ c
   end
 
@@ -55,7 +55,7 @@ end
     ψ_fx = const_itn(s; c, linkdim=4)
 
     x = 0.5
-    fx_x = calculate_fx(ψ_fx, x)
+    fx_x = calculate_fx(ψ_fx, x; alg="exact")
     @test fx_x ≈ c
   end
   funcs = [


### PR DESCRIPTION
Noticed that `calculate_fxyz(const_itn(s;c=2, linkdim=8),[0,0])` did not equal 2. 
This now works
```julia
L = 12
g = NamedGraph(SimpleGraph(uniform_tree(L)))
s = continuous_siteinds(g; map_dimension=2)
@show calculate_fxyz(const_itn(s;c=2, linkdim=8),[0,0])
````
But the test does not pass so my logic is not quite right...
