### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Run tests
 on: 
   push:
     branches:
-      - master
       - main
   pull_request:
 
@@ -12,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.10']
+        julia-version: ['1']
         julia-arch: [x64,]
         os: [macOS-latest, ubuntu-latest]
         exclude:


### PR DESCRIPTION
Removed an unnecessary reference to `master`. Also switching `1.10` to `1` for the Julia version, which means that it will automatically use the latest Julia release, so you don't have to change it manually as new Julia versions are released.