### PR TITLE
Change index_value_to_scalar to use a float base

### DIFF
--- a/src/IndexMaps/complexindexmap.jl
+++ b/src/IndexMaps/complexindexmap.jl
@@ -23,10 +23,11 @@ function imaginary_indices(imap::ComplexIndexMap, dim::Int64)
 end
 
 function index_value_to_scalar(imap::ComplexIndexMap, ind::Index, value::Int)
+  invb = float(dim(ind))^-digit(imap, ind)
   return if is_real(imap, ind)
-    (value) / (dim(ind)^digit(imap, ind))
+    (value) * invb
   else
-    im * (value) / (dim(ind)^digit(imap, ind))
+    im * (value) * invb
   end
 end
 function Base.copy(imap::ComplexIndexMap)
@@ -133,7 +134,7 @@ end
 function grid_points(imap::ComplexIndexMap, N::Int, d::Int)
   dims = dim.(dimension_inds(imap, d))
   @assert all(y -> y == first(dims), dims)
-  base = first(dims)
+  base = float(first(dims))
   Lre, Lim = length(real_indices(imap, d)), length(imag_indices(imap, d))
   are, aim = round(base^Lre / N), round(base^Lim / N)
   grid_points = [

--- a/src/IndexMaps/realindexmap.jl
+++ b/src/IndexMaps/realindexmap.jl
@@ -11,7 +11,7 @@ end
 index_digit(imap::RealIndexMap) = imap.index_digit
 index_dimension(imap::RealIndexMap) = imap.index_dimension
 function index_value_to_scalar(imap::RealIndexMap, ind::Index, value::Int)
-  return (value) / (dim(ind)^digit(imap, ind))
+  return (value) * (float(dim(ind))^-digit(imap, ind))
 end
 function Base.copy(imap::RealIndexMap)
   return RealIndexMap(copy(index_digit(imap)), copy(index_dimension(imap)))
@@ -78,7 +78,7 @@ end
 function grid_points(imap::RealIndexMap, N::Int, d::Int)
   dims = dim.(dimension_inds(imap, d))
   @assert all(y -> y == first(dims), dims)
-  base = first(dims)
+  base = float(first(dims))
   L = length(dimension_inds(imap, d))
   a = round(base^L / N)
   grid_points = [i * (a / base^L) for i in 0:(N + 1)]


### PR DESCRIPTION
When the number of digits `L` exceeds machine precision, `base^L` becomes 0, while `float(base)^L` is closer to the correct number
```julia
julia> 2^100
0

julia> 2.0^100
1.2676506002282294e30
```
Switching to use `float(base)`, we can do the following
```julia
julia> s = continuous_siteinds(named_comb_tree((1,100)); map_dimension=1);
       p = sin_itn(s);
       evaluate(p,[1]) - sin(1)

1.6653345369377348e-15 + 8.266735960441102e-17im
```
