### PR TITLE
Remove not_implemented()

### DIFF
--- a/src/IndexMaps/abstractindexmap.jl
+++ b/src/IndexMaps/abstractindexmap.jl
@@ -6,17 +6,15 @@ using ITensorNetworks: IndsNetwork, vertex_data
 abstract type AbstractIndexMap{VB,VD} end
 
 #These functions need to be defined on the concrete type for implementation
-function index_digit(imap::AbstractIndexMap) end
-function index_dimension(imap::AbstractIndexMap) end
-function Base.copy(imap::AbstractIndexMap) end
-function index_value_to_scalar(imap::AbstractIndexMap, ind::Index, value::Int) end
-function ITensors.inds(imap::AbstractIndexMap) end
-function ind(imap::AbstractIndexMap, args...) end
-function calculate_ind_values(
-  imap::AbstractIndexMap, xs::Vector, dims::Vector{Int}; kwargs...
-) end
-function grid_points(imap::AbstractIndexMap, N::Int, d::Int) end
-function rem_index(imap::AbstractIndexMap, ind::Index) end
+function index_digit end
+function index_dimension end
+#function Base.copy(imap::AbstractIndexMap) end
+function index_value_to_scalar end
+#function ITensors.inds(imap::AbstractIndexMap) end
+function ind end
+function calculate_ind_values end
+function grid_points end
+function rem_index end
 
 dimensions(imap::AbstractIndexMap) = Int64.(unique(collect(values(index_dimension(imap)))))
 dimension(imap::AbstractIndexMap) = maximum(dimensions(imap))

--- a/src/IndexMaps/abstractindexmap.jl
+++ b/src/IndexMaps/abstractindexmap.jl
@@ -6,19 +6,17 @@ using ITensorNetworks: IndsNetwork, vertex_data
 abstract type AbstractIndexMap{VB,VD} end
 
 #These functions need to be defined on the concrete type for implementation
-index_digit(imap::AbstractIndexMap) = not_implemented()
-index_dimension(imap::AbstractIndexMap) = not_implemented()
-Base.copy(imap::AbstractIndexMap) = not_implemented()
-index_value_to_scalar(imap::AbstractIndexMap, ind::Index, value::Int) = not_implemented()
-ITensors.inds(imap::AbstractIndexMap) = not_implemented()
-ind(imap::AbstractIndexMap, args...) = not_implemented()
+function index_digit(imap::AbstractIndexMap) end
+function index_dimension(imap::AbstractIndexMap) end
+function Base.copy(imap::AbstractIndexMap) end
+function index_value_to_scalar(imap::AbstractIndexMap, ind::Index, value::Int) end
+function ITensors.inds(imap::AbstractIndexMap) end
+function ind(imap::AbstractIndexMap, args...) end
 function calculate_ind_values(
   imap::AbstractIndexMap, xs::Vector, dims::Vector{Int}; kwargs...
-)
-  return not_implemented()
-end
-grid_points(imap::AbstractIndexMap, N::Int, d::Int) = not_implemented()
-rem_index(imap::AbstractIndexMap, ind::Index) = not_implemented()
+) end
+function grid_points(imap::AbstractIndexMap, N::Int, d::Int) end
+function rem_index(imap::AbstractIndexMap, ind::Index) end
 
 dimensions(imap::AbstractIndexMap) = Int64.(unique(collect(values(index_dimension(imap)))))
 dimension(imap::AbstractIndexMap) = maximum(dimensions(imap))

--- a/src/IndexMaps/abstractindexmap.jl
+++ b/src/IndexMaps/abstractindexmap.jl
@@ -6,14 +6,67 @@ using ITensorNetworks: IndsNetwork, vertex_data
 abstract type AbstractIndexMap{VB,VD} end
 
 #These functions need to be defined on the concrete type for implementation
+
+"""
+  index_digit(imap::AbstractIndexMap)
+
+Return the mapping from indices to digit number
+"""
 function index_digit end
+
+"""
+  index_dimension(imap::AbstractIndexMap)
+
+Return the mapping from index to corresponding dimension
+"""
 function index_dimension end
+
 #function Base.copy(imap::AbstractIndexMap) end
+
+"""
+  index_value_to_scalar(imap::AbstractIndexMap, ind::Index, value::Int)
+
+Calculate the corresponding grid point given an Index
+with a setting of value to its corresponding grid value
+
+calculate_ind_values and index_value_to_scalar should match input/outputs
+"""
 function index_value_to_scalar end
+
 #function ITensors.inds(imap::AbstractIndexMap) end
+
+"""
+  ind(imap::AbstractIndexMap, args...)
+
+Return the matching index given args (e.g. dim, digit)
+
+"""
 function ind end
+
+"""
+  calculate_ind_values(
+    imap::AbstractIndexMap, xs::Vector, dims::Vector{Int}; kwargs...
+    )
+
+Given a set of points xs with corresponding dimensions dims,
+return a dictionary mapping each index value to a setting
+
+calculate_ind_values and index_value_to_scalar should match input/outputs
+"""
 function calculate_ind_values end
+
+"""
+  grid_points(imap::AbstractIndexMap, N::Int, d::Int)
+
+Convenience function, return N uniform grid points of the dimension d
+"""
 function grid_points end
+
+"""
+  rem_index(imap::AbstractIndexMap, ind::Index)
+
+Remove an index from the index map
+"""
 function rem_index end
 
 dimensions(imap::AbstractIndexMap) = Int64.(unique(collect(values(index_dimension(imap)))))


### PR DESCRIPTION
It turns out that adding `not_implemented()` obscures the error when implementing a child type. Here we'll get `not_implemented() is not defined` as the error, but really we shouldn't define it so the error will show the type that Julia is attempting to use (in case its deep within a function call)

[See this post for more](https://www.oxinabox.net/2020/04/19/Julia-Antipatterns.html#notimplemented-exceptions)