### PR TITLE
Fix: Passing map_dimension to default_dimension_vertices (Issue #58)

### DIFF
--- a/src/digit_inds.jl
+++ b/src/digit_inds.jl
@@ -70,10 +70,11 @@ function real_digit_tag(vertex, dim::Int, digit::Int)
 end
 
 function digit_siteinds(
-  g::AbstractGraph,
-  dimension_vertices::Vector{Vector{V}}=default_dimension_vertices(g);
-  base=2,
+  g::AbstractGraph, dimension_vertices::Vector{Vector{V}}=[[]]; base=2, kwargs...
 ) where {V}
+  if isempty(dimension_vertices[1])
+    dimension_vertices = default_dimension_vertices(g; kwargs...)
+  end
   is = IndsNetwork(g; site_space=Dictionary(vertices(g), [Index[] for v in vertices(g)]))
   for (dim, verts) in enumerate(dimension_vertices)
     for (digit, v) in enumerate(verts)
@@ -86,10 +87,17 @@ end
 
 function complex_digit_siteinds(
   g::AbstractGraph,
-  real_dimension_vertices::Vector{Vector{V}}=default_dimension_vertices(g),
-  imag_dimension_vertices::Vector{Vector{V}}=default_dimension_vertices(g);
+  real_dimension_vertices::Vector{Vector{V}}=[[]],
+  imag_dimension_vertices::Vector{Vector{V}}=[[]];
   base=2,
+  kwargs...,
 ) where {V}
+  if isempty(real_dimension_vertices[1])
+    real_dimension_vertices = default_dimension_vertices(g; kwargs...)
+  end
+  if isempty(imag_dimension_vertices[1])
+    imag_dimension_vertices = default_dimension_vertices(g; kwargs...)
+  end
   is = IndsNetwork(g; site_space=Dictionary(vertices(g), [Index[] for v in vertices(g)]))
   for (dim, verts) in enumerate(real_dimension_vertices)
     for (digit, v) in enumerate(verts)

--- a/src/indsnetworkmap.jl
+++ b/src/indsnetworkmap.jl
@@ -55,7 +55,7 @@ function RealIndsNetworkMap(s::IndsNetwork, args...; kwargs...)
 end
 
 function RealIndsNetworkMap(g::AbstractGraph, args...; base::Int=2, kwargs...)
-  s = digit_siteinds(g, args...; base)
+  s = digit_siteinds(g, args...; base, kwargs...)
   return RealIndsNetworkMap(s, args...; kwargs...)
 end
 
@@ -68,7 +68,7 @@ function ComplexIndsNetworkMap(s::IndsNetwork, args...; kwargs...)
 end
 
 function ComplexIndsNetworkMap(g::AbstractGraph, args...; base::Int=2, kwargs...)
-  s = complex_digit_siteinds(g, args...; base)
+  s = complex_digit_siteinds(g, args...; base, kwargs...)
   return ComplexIndsNetworkMap(s, args...; kwargs...)
 end
 


### PR DESCRIPTION
As explained in Issue #58 and fixed in PR #59 for TCI branch, but now for main branch.